### PR TITLE
Update Namespace Ordering to be Alphabetical

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -2,9 +2,9 @@
 
 namespace HumanMade\SimpleSaml\Admin;
 
-use OneLogin_Saml2_IdPMetadataParser;
-use function HumanMade\SimpleSaml\is_sso_enabled_network_wide;
 use function HumanMade\SimpleSaml\instance;
+use function HumanMade\SimpleSaml\is_sso_enabled_network_wide;
+use OneLogin_Saml2_IdPMetadataParser;
 
 /**
  * Bootstrap config/admin related actions


### PR DESCRIPTION
HM linter was complaining about non-alphabetical namespaces `use`s - this addresses this simple complaint and brings the codebase back in-line with HM's standards.