### PR TITLE
Implement Single Logout Protocol

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -41,7 +41,7 @@ function bootstrap() {
 	add_action( 'template_redirect', __NAMESPACE__ . '\\endpoint', 9 );
 	add_action( 'login_message', __NAMESPACE__ . '\\login_form_link' );
 	add_action( 'wp_authenticate', __NAMESPACE__ . '\\authenticate_with_sso' );
-	add_action( 'wp_logout', __NAMESPACE__ . '\\go_home' );
+	add_action( 'wp_logout', __NAMESPACE__ . '\\logout' );
 
 	add_action( 'wpsimplesaml_action_login', __NAMESPACE__ . '\\cross_site_sso' );
 	add_action( 'wpsimplesaml_action_verify', __NAMESPACE__ . '\\cross_site_sso' );
@@ -578,6 +578,14 @@ function signon( $user ) {
 function signout() {
 	wp_destroy_current_session();
 	wp_clear_auth_cookie();
+}
+
+/**
+ * Send LogoutRequest to IdP when user logs out.
+ */
+function logout() {
+	$redirect_url = get_redirection_url();
+	instance()->logout( $redirect_url );
 }
 
 /**


### PR DESCRIPTION
This fixes #5. Thoe workflow is are as follows:

1. The user logs out from Wordpress.
    1. After the user has been signed out the plugin send logout request to IdP's SLS.
    2. The IdP logs out the user and sends logout response to `sso/sls` endpoint.
    3. After processing the response the plugin redirects the user to the original redirect URL or `/wp-admin`
2. The user logs out from IdP or another SP.
    1. The IdP sends logout request to `sso/sls` endpoint with a redirect.
    2. The plugin signs out the user and sends logout response to IdP with redirect.

