### PR TITLE
Include is_plugin_active_for_network

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -53,6 +53,12 @@ function bootstrap() {
 	add_action( 'wpsimplesaml_action_metadata', __NAMESPACE__ . '\\action_metadata' );
 
 	add_action( 'wpsimplesaml_user_created', __NAMESPACE__ . '\\map_user_roles', 10, 2 );
+
+	// is_plugin_active_for_network can only be used once the plugin.php file is
+	// included.
+	if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
+		require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+	}
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -55,7 +55,8 @@ function bootstrap() {
 	add_action( 'wpsimplesaml_user_created', __NAMESPACE__ . '\\map_user_roles', 10, 2 );
 
 	// is_plugin_active_for_network can only be used once the plugin.php file is
-	// included.
+	// included. More information can be found here:
+	// https://codex.wordpress.org/Function_Reference/is_plugin_active_for_network
 	if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
 		require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -29,12 +29,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 namespace HumanMade\SimpleSaml;
 
-// is_plugin_active_for_network can only be used once the plugin.php file is
-// included.
-if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
-	require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
-}
-
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/admin/namespace.php';
 

--- a/plugin.php
+++ b/plugin.php
@@ -29,6 +29,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 namespace HumanMade\SimpleSaml;
 
+// is_plugin_active_for_network can only be used once the plugin.php file is
+// included.
+if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
+    require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+}
+
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/admin/namespace.php';
 

--- a/plugin.php
+++ b/plugin.php
@@ -32,7 +32,7 @@ namespace HumanMade\SimpleSaml;
 // is_plugin_active_for_network can only be used once the plugin.php file is
 // included.
 if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
-    require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+	require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
 }
 
 require_once __DIR__ . '/inc/namespace.php';


### PR DESCRIPTION
On Multisite networks, the wp-simple-saml plugin will error out with the error: `Call to undefined function HumanMade\SimpleSaml\is_plugin_active_for_network()`. This issue has been filed in Issue #15.

The solution is inspired by (Codex)[https://codex.wordpress.org/Function_Reference/is_plugin_active_for_network]. We now check if the function `is_plugin_active_for_network` exists. If it doesn't, include the wp-admin's `plugin.php` file which contains the `is_plugin_active_for_network` function definition.