### PR TITLE
Fix fatal error when running plugin on not-multisite.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -622,8 +622,11 @@ function cross_site_sso_redirect( $url ) {
  * @return int Blog ID if found, 0 if not
  */
 function get_blog_id( $url ) {
-	$fragments = wp_parse_url( $url );
+	if ( ! is_multisite() ) {
+		return get_current_blog_id();
+	}
 
+	$fragments = wp_parse_url( $url );
 	if ( empty( $fragments ) || empty( $fragments['host'] ) ) {
 		return 0;
 	}


### PR DESCRIPTION
When running classic flavour WordPress, this change fixes a fatal error caused
by a reference to an unloaded, multisite-only function. As this unit of code
was only concerned about fetching the site ID from the current URL, we can
hardcode the return value for not-multisite.

Fixes #28