### PR TITLE
Fix: remove `version` tag from `composer.json`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
 	"keywords": [ "saml","wordpress","sso","onelogin","single-sign-on" ],
 	"homepage": "https://github.com/humanmade/wp-simple-saml",
 	"license": "GPL-3.0-or-later",
-	"version": "0.1.0",
 	"authors": [
 		{
 			"name": "Shady Sharaf",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "360da5cf2314301a95bfa77dcd8ee1b1",
+    "content-hash": "a686dbbc7aa978d8659d6c1805435145",
     "packages": [
         {
             "name": "onelogin/php-saml",


### PR DESCRIPTION
Our recent tags are not showing on Packagist because our config file had a
hardcoded version number, and this confuses Composer's understanding of what
version a particular tag is (e.g. is it the tag number, or the hardcoded num?).

There is generally no need to manually track version numbers in a text file for
Composer, so we're simply removing this.