### PR TITLE
Backslash range (-) character

### DIFF
--- a/vendor/robrichards/xmlseclibs/src/Utils/XPath.php
+++ b/vendor/robrichards/xmlseclibs/src/Utils/XPath.php
@@ -7,7 +7,7 @@ class XPath
     const ALPHANUMERIC = '\w\d';
     const NUMERIC = '\d';
     const LETTERS = '\w';
-    const EXTENDED_ALPHANUMERIC = '\w\d\s-_:\.';
+    const EXTENDED_ALPHANUMERIC = '\w\d\s\-_:\.';
 
     const SINGLE_QUOTE = '\'';
     const DOUBLE_QUOTE = '"';


### PR DESCRIPTION
Not backslashing the range character was causing preg_replace to return NULL, resulting in an invalid XPath query in XMLSecurityDSig.php