### PR TITLE
Multi domain handling patch

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,6 +34,22 @@ use OneLogin\Saml2\Auth;
 define( 'WP_SIMPLE_SAML_PLUGIN_FILE', __FILE__ );
 
 /**
+ * Filter to allow redirection in sso configured domains
+ *
+ * @action init
+ */
+function wpsimplesaml_allowed_redirect_hosts($allowed) {
+        $settings =  Admin\get_sso_settings( 'sso_whitelisted_hosts' );
+        if(!empty($settings)) {
+              $allowed = array_merge($allowed, explode( ',', $settings ));
+        }
+        $admin_url = admin_url();
+        $main_host = wp_parse_url($admin_url, PHP_URL_HOST );
+        $allowed[] = $main_host;
+        return $allowed;
+}
+
+/**
  * Bootstrap the plugin, adding required actions and filters
  *
  * @action init
@@ -54,6 +70,9 @@ function bootstrap() {
 
 	add_action( 'wpsimplesaml_user_created', __NAMESPACE__ . '\\map_user_roles', 10, 2 );
 
+	// add SSO delegation whitelisted hosts to wp allowed_redirect_hosts
+    add_filter('allowed_redirect_hosts',__NAMESPACE__ . '\\wpsimplesaml_allowed_redirect_hosts' );	
+	
 	// is_plugin_active_for_network can only be used once the plugin.php file is
 	// included. More information can be found here:
 	// https://codex.wordpress.org/Function_Reference/is_plugin_active_for_network
@@ -204,6 +223,9 @@ function instance() {
 	}
 
 	if ( empty( $instance ) ) {
+        $newHost = $_SERVER['HTTP_HOST'];
+        $acs = wp_parse_url($config['sp']['assertionConsumerService']['url'], PHP_URL_HOST );
+        $config['sp']['assertionConsumerService']['url'] = str_replace($acs, $newHost, $config['sp']['assertionConsumerService']['url']);
 		$instance = new Auth( $config );
 	}
 
@@ -662,6 +684,9 @@ function get_redirection_url() {
 	// If redirection URL is invalid or empty, fall back to admin_url()
 	if ( empty( $redirect ) || ( $redirect && ! filter_var( $redirect, FILTER_VALIDATE_URL ) ) ) {
 		$redirect = admin_url();
+		$newHost = $_SERVER['HTTP_HOST'];
+		$acs = wp_parse_url($redirect, PHP_URL_HOST );
+		$redirect = str_replace($acs, $newHost, $redirect);		
 	}
 
 	/**
@@ -750,5 +775,5 @@ function get_user_roles_from_sso( \WP_User $user, array $attributes ) {
 		}
 	}
 
-	return $network_roles ?? (array) $roles;
+	return empty($network_roles) ? (array) $roles : $network_roles;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -38,15 +38,15 @@ define( 'WP_SIMPLE_SAML_PLUGIN_FILE', __FILE__ );
  *
  * @action init
  */
-function wpsimplesaml_allowed_redirect_hosts($allowed) {
-        $settings =  Admin\get_sso_settings( 'sso_whitelisted_hosts' );
-        if(!empty($settings)) {
-              $allowed = array_merge($allowed, explode( ',', $settings ));
-        }
-        $admin_url = admin_url();
-        $main_host = wp_parse_url($admin_url, PHP_URL_HOST );
-        $allowed[] = $main_host;
-        return $allowed;
+function wpsimplesaml_allowed_redirect_hosts( $allowed ) {
+	$settings = Admin\get_sso_settings( 'sso_whitelisted_hosts' );
+	if ( ! empty( $settings ) ) {
+			$allowed = array_merge( $allowed, explode( ',', $settings ) );
+	}
+	$admin_url = admin_url();
+	$main_host = wp_parse_url( $admin_url, PHP_URL_HOST );
+	$allowed[] = $main_host;
+	return $allowed;
 }
 
 /**
@@ -71,8 +71,8 @@ function bootstrap() {
 	add_action( 'wpsimplesaml_user_created', __NAMESPACE__ . '\\map_user_roles', 10, 2 );
 
 	// add SSO delegation whitelisted hosts to wp allowed_redirect_hosts
-    add_filter('allowed_redirect_hosts',__NAMESPACE__ . '\\wpsimplesaml_allowed_redirect_hosts' );	
-	
+	add_filter( 'allowed_redirect_hosts', __NAMESPACE__ . '\\wpsimplesaml_allowed_redirect_hosts' );
+
 	// is_plugin_active_for_network can only be used once the plugin.php file is
 	// included. More information can be found here:
 	// https://codex.wordpress.org/Function_Reference/is_plugin_active_for_network
@@ -223,9 +223,9 @@ function instance() {
 	}
 
 	if ( empty( $instance ) ) {
-        $newHost = $_SERVER['HTTP_HOST'];
-        $acs = wp_parse_url($config['sp']['assertionConsumerService']['url'], PHP_URL_HOST );
-        $config['sp']['assertionConsumerService']['url'] = str_replace($acs, $newHost, $config['sp']['assertionConsumerService']['url']);
+		$new_host = $_SERVER['HTTP_HOST'];
+		$acs = wp_parse_url( $config['sp']['assertionConsumerService']['url'], PHP_URL_HOST );
+		$config['sp']['assertionConsumerService']['url'] = str_replace( $acs, $new_host, $config['sp']['assertionConsumerService']['url'] );
 		$instance = new Auth( $config );
 	}
 
@@ -684,9 +684,9 @@ function get_redirection_url() {
 	// If redirection URL is invalid or empty, fall back to admin_url()
 	if ( empty( $redirect ) || ( $redirect && ! filter_var( $redirect, FILTER_VALIDATE_URL ) ) ) {
 		$redirect = admin_url();
-		$newHost = $_SERVER['HTTP_HOST'];
-		$acs = wp_parse_url($redirect, PHP_URL_HOST );
-		$redirect = str_replace($acs, $newHost, $redirect);		
+		$new_host = $_SERVER['HTTP_HOST'];
+		$acs = wp_parse_url( $redirect, PHP_URL_HOST );
+		$redirect = str_replace( $acs, $new_host, $redirect );
 	}
 
 	/**
@@ -775,5 +775,5 @@ function get_user_roles_from_sso( \WP_User $user, array $attributes ) {
 		}
 	}
 
-	return empty($network_roles) ? (array) $roles : $network_roles;
+	return empty( $network_roles ) ? (array) $roles : $network_roles;
 }


### PR DESCRIPTION
Workaround to handle multi domain.
This inject the "SSO delegation whitelisted hosts" array into the Wordpress' allowed redirect hosts array to prevent the redirection on the main domain.