### PR TITLE
New Setting to Control Account Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ Depending on whether the plugin is network-activated or not, you will need to go
 - `SSO Status`
 is how the plugin integrates with WordPress login process, available options are `Disable`, `Display login link` which only provides a link in the login form, `Force redirect` which overrides the login form altogether and directly goes to SSO login page.
 - `SSO Base URL` (optional)
-is the home URL of the WordPress site that serves as the delegate ( main service provider ) to which SAML responses will be posted, usually this is the main site of the network, and is the same value for `siteurl` option, eg `https://my.site/`
+is the home URL of the WordPress site that serves as the delegate ( main service provider ) to which SAML responses will be posted, usually this is the main site of the network, and is the same value for `siteurl` option, eg `https://my.site/`.
 - `SSO IdP Metadata` (required, if not filtered)
 Copy of the SSO IdP metadata XML file, which can also be passed via either `wpsimplesaml_idp_metadata_xml_path` for a path to the XML file, or `wpsimplesaml_idp_metadata_xml` for the contents of the XML, or `wpsimplesaml_idp_metadata` for the configuration array.
+- `SSO Create user if it does not exists`
+Controls if new accounts will be created if they don't exist already.
 - `SSO delegation whitelisted hosts`
-List of hosts to whitelist during delegation of SAML responses, ie: secondary domains that needs to use SSO as well from the same IdP. Local sites are allowed by default.  
+List of hosts to whitelist during delegation of SAML responses, ie: secondary domains that needs to use SSO as well from the same IdP. Local sites are allowed by default.
 - `SSO Role Management`
-Enables developers to assign different roles to users based on SAML Responses, disabled by default, and is controlled via a few filters,  
+Enables developers to assign different roles to users based on SAML Responses, disabled by default, and is controlled via a few filters.
 - `SSO Debug via Cookies`
 Allows developers to use a special cookie named `sso_debug` to override the `SSO Status` option during testing. Possible value of the cookie are `force` and `link`, which are self-explanatory.
 - `SSO Config validation`

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -128,12 +128,13 @@ function config_admin_notice() {
  */
 function get_sso_settings( $option = null ) {
 	$options = [
-		'sso_enabled'           => '',
-		'sso_debug'             => 0,
-		'sso_sp_base'           => is_sso_enabled_network_wide() ? get_home_url( get_network()->site_id, '/' ) : home_url( '/' ),
-		'sso_role_management'   => '',
-		'sso_whitelisted_hosts' => '',
-		'sso_idp_metadata'      => '',
+		'sso_enabled'              => '',
+		'sso_debug'                => 0,
+		'sso_sp_base'              => is_sso_enabled_network_wide() ? get_home_url( get_network()->site_id, '/' ) : home_url( '/' ),
+		'sso_role_management'      => '',
+		'sso_whitelisted_hosts'    => '',
+		'sso_idp_metadata'         => '',
+		'sso_create_if_not_exists' => 1,
 	];
 
 	// Network options is used instead if the plugin is activated network-wide
@@ -211,6 +212,14 @@ function settings_fields() {
 			<textarea name="sso_idp_metadata" id="sso_idp_metadata" style="width: 100%; height: 200px" <?php disabled( (bool) $xml ); ?>><?php echo esc_html( $value ); ?></textarea>
 			<?php
 		}
+	}, $settings_section, 'sso_settings' );
+
+	register_setting( $settings_section, 'sso_create_if_not_exists', 'absint' );
+	add_settings_field( 'sso_create_if_not_exists', __( 'SSO Create user if it does not exists', 'wp-simple-saml' ), function () use ( $options ) {
+		$value   = $options['sso_create_if_not_exists'];
+		?>
+		<input type="checkbox" name="sso_create_if_not_exists" id="sso_create_if_not_exists" value="1" <?php checked( $value ); ?>>
+		<?php
 	}, $settings_section, 'sso_settings' );
 
 	register_setting( $settings_section, 'sso_role_management', 'sanitize_text' );
@@ -349,6 +358,12 @@ function save_network_settings_fields() {
 
 	if ( isset( $_POST['sso_idp_metadata'] ) ) { // WPCS input var ok
 		update_site_option( 'sso_idp_metadata', wp_unslash( $_POST['sso_idp_metadata'] ) ); // WPCS input var ok
+	}
+
+	if ( isset( $_POST['sso_create_if_not_exists'] ) ) { // WPCS input var ok
+		update_site_option( 'sso_create_if_not_exists', absint( $_POST['sso_create_if_not_exists'] ) ); // WPCS input var ok
+	} else {
+		update_site_option( 'sso_create_if_not_exists', 0 ); // WPCS input var ok
 	}
 }
 

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -216,7 +216,7 @@ function settings_fields() {
 
 	register_setting( $settings_section, 'sso_create_if_not_exists', 'absint' );
 	add_settings_field( 'sso_create_if_not_exists', __( 'SSO Create user if it does not exists', 'wp-simple-saml' ), function () use ( $options ) {
-		$value   = $options['sso_create_if_not_exists'];
+		$value = $options['sso_create_if_not_exists'];
 		?>
 		<input type="checkbox" name="sso_create_if_not_exists" id="sso_create_if_not_exists" value="1" <?php checked( $value ); ?>>
 		<?php

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -373,7 +373,7 @@ function get_or_create_wp_user( \OneLogin\Saml2\Auth $saml ) {
 	}
 
 	// No user yet ? lets create a new one.
-	if ( empty( $user ) ) {
+	if ( empty( $user ) && Admin\get_sso_settings( 'sso_create_if_not_exists' ) ) {
 
 		$first_name = isset( $map['first_name'], $attributes[ $map['first_name'] ] ) && is_array( $attributes[ $map['first_name'] ] ) ? reset( $attributes[ $map['first_name'] ] ) : '';
 		$last_name  = isset( $map['last_name'], $attributes[ $map['last_name'] ] ) && is_array( $attributes[ $map['last_name'] ] ) ? reset( $attributes[ $map['last_name'] ] ) : '';


### PR DESCRIPTION
Add a new setting to control whether new accounts to the Wordpress instance if they don't exist.