### PR TITLE
Fix roles in multisite

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -513,9 +513,10 @@ function map_user_roles( $user, array $attributes ) {
 			$all_site_ids = new \WP_Site_Query( [
 				'network' => get_network()->id,
 				'fields'  => 'ids',
+				'number'  => 999,
 			] );
 
-			foreach ( $all_site_ids as $site_id ) {
+			foreach ( $all_site_ids->sites as $site_id ) {
 				switch_to_blog( $site_id );
 				$user->for_site( $site_id );
 				$user->set_role( reset( $roles['network'] ) );


### PR DESCRIPTION
When the network roles syncing is enabled, there's a bug in the `foreach` trying to iterate over the object (which doesn't implement iterable etc). So far as I can see, this would never have worked.

I also increased the `number` param, else it will default to 100. There is no support for `-1` so I'm not sure what the ideal fix here is, but even in our own case we have networks with > 100 sites.
