### PR TITLE
PHP8 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require": {
-		"onelogin/php-saml": "^3.0"
+		"onelogin/php-saml": "^4.0"
 	},
 	"require-dev": {
 		"humanmade/coding-standards": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -4,38 +4,39 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a686dbbc7aa978d8659d6c1805435145",
+    "content-hash": "86d84d9b6fce14a25fc65096b0bf6334",
     "packages": [
         {
             "name": "onelogin/php-saml",
-            "version": "v3.0.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/onelogin/php-saml.git",
-                "reference": "920c2240e48c9a74aad4129720f48fbf3d5fee47"
+                "reference": "b22a57ebd13e838b90df5d3346090bc37056409d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/onelogin/php-saml/zipball/920c2240e48c9a74aad4129720f48fbf3d5fee47",
-                "reference": "920c2240e48c9a74aad4129720f48fbf3d5fee47",
+                "url": "https://api.github.com/repos/onelogin/php-saml/zipball/b22a57ebd13e838b90df5d3346090bc37056409d",
+                "reference": "b22a57ebd13e838b90df5d3346090bc37056409d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "robrichards/xmlseclibs": "^3.0"
+                "php": ">=7.3",
+                "robrichards/xmlseclibs": ">=3.1.1"
             },
             "require-dev": {
-                "pdepend/pdepend": "^2.5.0",
-                "php-coveralls/php-coveralls": "^1.0.2 || ^2.0",
-                "phploc/phploc": "^2.1 || ^3.0 || ^4.0",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1",
-                "sebastian/phpcpd": "^2.0 || ^3.0 || ^4.0",
-                "squizlabs/php_codesniffer": "^3.1.1"
+                "pdepend/pdepend": "^2.8.0",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phploc/phploc": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "phpunit/phpunit": "^9.5",
+                "sebastian/phpcpd": "^4.0 || ^5.0 || ^6.0 ",
+                "squizlabs/php_codesniffer": "^3.5.8"
             },
             "suggest": {
                 "ext-curl": "Install curl lib to be able to use the IdPMetadataParser for parsing remote XMLs",
-                "ext-gettext": "Install gettext and php5-gettext libs to handle translations",
-                "ext-openssl": "Install openssl lib in order to handle with x509 certs (require to support sign and encryption)"
+                "ext-dom": "Install xml lib",
+                "ext-openssl": "Install openssl lib in order to handle with x509 certs (require to support sign and encryption)",
+                "ext-zlib": "Install zlib"
             },
             "type": "library",
             "autoload": {
@@ -54,20 +55,25 @@
                 "onelogin",
                 "saml"
             ],
-            "time": "2018-10-02T16:02:37+00:00"
+            "support": {
+                "email": "sixto.garcia@onelogin.com",
+                "issues": "https://github.com/onelogin/php-saml/issues",
+                "source": "https://github.com/onelogin/php-saml/"
+            },
+            "time": "2022-07-15T20:44:36+00:00"
         },
         {
             "name": "robrichards/xmlseclibs",
-            "version": "3.0.4",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robrichards/xmlseclibs.git",
-                "reference": "0a53d3c3aa87564910cae4ed01416441d3ae0db5"
+                "reference": "f8f19e58f26cdb42c54b214ff8a820760292f8df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/0a53d3c3aa87564910cae4ed01416441d3ae0db5",
-                "reference": "0a53d3c3aa87564910cae4ed01416441d3ae0db5",
+                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/f8f19e58f26cdb42c54b214ff8a820760292f8df",
+                "reference": "f8f19e58f26cdb42c54b214ff8a820760292f8df",
                 "shasum": ""
             },
             "require": {
@@ -92,7 +98,11 @@
                 "xml",
                 "xmldsig"
             ],
-            "time": "2019-11-05T11:44:22+00:00"
+            "support": {
+                "issues": "https://github.com/robrichards/xmlseclibs/issues",
+                "source": "https://github.com/robrichards/xmlseclibs/tree/3.1.1"
+            },
+            "time": "2020-09-05T13:00:25+00:00"
         }
     ],
     "packages-dev": [
@@ -272,5 +282,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
In a php8 environment, the following error is being thrown: `Function libxml_disable_entity_loader() is deprecated`

Based on the stack trace: 
```
 in OneLogin\Saml2\Utils::loadXML called at /srv/www/wp-content/plugins/wp-simple-saml/vendor/onelogin/php-saml/src/Saml2/IdPMetadataParser.php (115)
 in OneLogin\Saml2\IdPMetadataParser::parseXML called at /srv/www/wp-content/plugins/wp-simple-saml/inc/admin/namespace.php (58)
 in HumanMade\SimpleSaml\Admin\get_config called at /srv/www/wp/wp-includes/class-wp-hook.php (307)
 in WP_Hook::apply_filters called at /srv/www/wp/wp-includes/plugin.php (189)
 in apply_filters called at /srv/www/wp-content/plugins/wp-simple-saml/inc/namespace.php (201)
 in HumanMade\SimpleSaml\instance called at /srv/www/wp-content/plugins/wp-simple-saml/inc/namespace.php (165)
 in HumanMade\SimpleSaml\authenticate_with_sso called at /srv/www/wp/wp-includes/class-wp-hook.php (309)
 in WP_Hook::apply_filters called at /srv/www/wp/wp-includes/class-wp-hook.php (331)
 in WP_Hook::do_action called at /srv/www/wp/wp-includes/plugin.php (522)
 in do_action_ref_array called at /srv/www/wp/wp-includes/user.php (67)
 in wp_signon called at /srv/www/wp/wp-login.php (1211)
```

Updates `onelogin/php-saml` to use ^4.0, which includes support for php >8.

Reference https://github.com/SAML-Toolkits/php-saml/issues/453

