### PR TITLE
Catch Throwable in order to support both PHP 5 and PHP 7+

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -57,6 +57,10 @@ function get_config() {
 			$idp_xml  = trim( apply_filters( 'wpsimplesaml_idp_metadata_xml', '' ) );
 			$settings = IdPMetadataParser::parseXML( $idp_xml );
 		}
+	} catch ( \Throwable $e ) {
+		return new \WP_Error( 'invalid-idp-metadata', __( 'Invalid IdP XML metadata', 'wp-simple-saml' ), [
+			'errors' => $e->getMessage(),
+		] );
 	} catch ( \Exception $e ) {
 		return new \WP_Error( 'invalid-idp-metadata', __( 'Invalid IdP XML metadata', 'wp-simple-saml' ), [
 			'errors' => $e->getMessage(),

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -294,6 +294,8 @@ function get_metadata() {
 	try {
 		$metadata = $settings->getSPMetadata();
 		$errors   = $settings->validateMetadata( $metadata );
+	} catch ( \Throwable $e ) {
+		$errors = $e->getMessage();
 	} catch ( \Exception $e ) {
 		$errors = $e->getMessage();
 	}
@@ -360,6 +362,9 @@ function process_response() {
 
 		}
 		$saml->processResponse();
+	} catch ( \Throwable $e ) {
+		/* translators: %s = error message */
+		return new \WP_Error( 'invalid-saml', sprintf( esc_html__( 'Error: Could not parse the authentication response, please forward this error to your administrator: "%s"', 'wp-simple-saml' ), esc_html( $e->getMessage() ) ) );
 	} catch ( \Exception $e ) {
 		/* translators: %s = error message */
 		return new \WP_Error( 'invalid-saml', sprintf( esc_html__( 'Error: Could not parse the authentication response, please forward this error to your administrator: "%s"', 'wp-simple-saml' ), esc_html( $e->getMessage() ) ) );


### PR DESCRIPTION
This PR updates the three existing `try`—`catch` blocks to try and catch a `Throwable` first (which will work in PHP 7+) before the current code targeting an `Exception` is executed.

This works on PHP 5-8 (see [here](https://www.php.net/manual/en/language.errors.php7.php#119652)), and allows all the `Error` instances thrown by OneLogin to be caught on PHP 7 or 8 (e.g., #78).