### PR TITLE
Update plugin version to 0.5.1

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Simple SAML
 Description: Integrate SAML 2.0 IDP without the hassle
 Author: Shady Sharaf, Human Made
-Version: 0.4.1
+Version: 0.5.0
 Author URI: http://hmn.md
 Text Domain: wp-simple-saml
 Domain Path: /language/

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Simple SAML
 Description: Integrate SAML 2.0 IDP without the hassle
 Author: Shady Sharaf, Human Made
-Version: 0.5.0
+Version: 0.5.1
 Author URI: http://hmn.md
 Text Domain: wp-simple-saml
 Domain Path: /language/


### PR DESCRIPTION
### Issue
The plugin version is identified incorrectly, as `0.4.1` rather than `0.5.1`.

### Cause
The plugin version in `plugin.php` in release `0.5.1` is incorrect. It is `0.4.1` rather than `0.5.1`. 

### Resolution
Update `plugin.php` to reflect the current version.