### PR TITLE
Add .wp-env.json

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
+	"config": {
+		"WP_DEBUG_DISPLAY": false,
+		"WP_DEBUG_LOG": true
+	},
+	"plugins": [
+		"."
+	]
+}


### PR DESCRIPTION
Having a `.wp-env.json` can reduce the friction and facilitate the running of the plugin for testing/development with specific settings.