### PR TITLE
Removes line breaks and spaces from inline js

### DIFF
--- a/assets/csr.js
+++ b/assets/csr.js
@@ -1,0 +1,3 @@
+setTimeout( function() {
+    document.getElementById( 'sso_form' ).submit();
+}, 100 );

--- a/assets/csr.js
+++ b/assets/csr.js
@@ -1,3 +1,3 @@
-setTimeout( function() {
+setTimeout( function () {
     document.getElementById( 'sso_form' ).submit();
 }, 100 );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -671,7 +671,7 @@ function cross_site_sso_redirect( $url ) {
 		?>
 	</form>
 	<?php // @codingStandardsIgnoreEnd ?>
-	<?php // Removes line break and spaces from the script below, so it could be hash properly to be excluded from the Browser CSP. ?>
+	<?php // Removes line breaks and spaces from the script below, so it can be hashed properly to be excluded from the Browser CSP. ?>
 <script>setTimeout(function(){document.getElementById('sso_form').submit();},100);</script>
 	<?php
 	exit;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -670,10 +670,14 @@ function cross_site_sso_redirect( $url ) {
 		do_action( 'wpsimplesaml_cross_sso_form_inputs' );
 		?>
 	</form>
-	<?php // @codingStandardsIgnoreEnd ?>
-	<?php // Removes line breaks and spaces from the script below, so it can be hashed properly to be excluded from the Browser CSP. ?>
-<script>setTimeout(function(){document.getElementById('sso_form').submit();},100);</script>
-	<?php
+	<?php 
+	wp_enqueue_script(
+		'wp-simple-saml-csr',
+		plugins_url( '/assets/csr.js', PLUGIN_FILE ),
+		[],
+		null
+	);
+	print_footer_scripts();
 	exit;
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -671,13 +671,8 @@ function cross_site_sso_redirect( $url ) {
 		?>
 	</form>
 	<?php // @codingStandardsIgnoreEnd ?>
-
-	<script>
-		setTimeout( function () {
-			document.getElementById( 'sso_form' ).submit();
-		}, 100 );
-	</script>
-
+	<?php // Removes line break and spaces from the script below, so it could be hash properly to be excluded from the Browser CSP. ?>
+<script>setTimeout(function(){document.getElementById('sso_form').submit();},100);</script>
 	<?php
 	exit;
 }

--- a/plugin.php
+++ b/plugin.php
@@ -31,6 +31,8 @@ namespace HumanMade\SimpleSaml;
 
 use WP_CLI;
 
+const PLUGIN_FILE = __FILE__;
+
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/admin/namespace.php';
 


### PR DESCRIPTION
For a cross site sso, this plugin use inline javascript to submit the form from the main site URL.

For some site that implement strict CSP and doesn't allow [unsafe-inline](https://content-security-policy.com/unsafe-inline/), cause this script to get blocked.

The solution is to able to hash this script and allowed it from the header.
The problem with hashing this script while having line breaks and spaces, could potentially cause the wrong hash.

This PR is to remove the line breaks and spaces to make the hash consistent.